### PR TITLE
several fixes to accomodate latest golden-solution screens

### DIFF
--- a/docs/src/components/pages/Drawer/ExampleWithPanel.js
+++ b/docs/src/components/pages/Drawer/ExampleWithPanel.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Button from 'uxi/Button';
 import Drawer from 'uxi/Drawer';
+import TextField from 'uxi/Input/TextField';
 import Panel, { PanelHeader, PanelContent, PanelFooter } from 'uxi/Panel';
 import { Close } from 'uxi/Icons';
 
@@ -42,7 +43,10 @@ class ExampleWithPanel extends Component {
         >
           <Panel onClose={() => this.setState({ showSidePanelLeft: false })}>
             <PanelHeader title={'Notifications'} />
-            <PanelContent>Some more content goes here</PanelContent>
+            <PanelContent>
+              first focusable element inside drawer gets focus on open
+              <Button>button</Button>
+            </PanelContent>
             <PanelFooter />
           </Panel>
         </Drawer>
@@ -54,7 +58,11 @@ class ExampleWithPanel extends Component {
         >
           <Panel onClose={() => this.setState({ showSidePanelRight: false })}>
             <PanelHeader title={'Notifications'} />
-            <PanelContent>Some more content goes here</PanelContent>
+            <PanelContent>
+              first focusable element inside drawer gets focus on open
+              <TextField placeholder="an input" />
+              <Button>button</Button>
+            </PanelContent>
           </Panel>
         </Drawer>
 
@@ -65,7 +73,7 @@ class ExampleWithPanel extends Component {
         >
           <Panel onClose={undefined} >
             <PanelHeader title={'Review Changes'} />
-            <PanelContent style={{ padding: '16px' }}>
+            <PanelContent style={{ padding: '16px' }}>
               <h3>old list:</h3>
               <ul>
                 <li> - banana</li>

--- a/docs/src/components/pages/Inputs/Radio/ExampleDefaultValueRadioGroup.js
+++ b/docs/src/components/pages/Inputs/Radio/ExampleDefaultValueRadioGroup.js
@@ -8,9 +8,9 @@ const ExampleDefaultValueRadioGroup = () => (
       name="isPayingCustomer"
       onChange={(event, val) => { }}
     >
-      <Radio value="true" label="Yes" />
-      <br />
       <Radio value="false" label="No" />
+      <br />
+      <Radio value="true" label="Yes" />
     </RadioGroup>
   </div>
 );

--- a/src/Button/ButtonComponent.js
+++ b/src/Button/ButtonComponent.js
@@ -38,7 +38,7 @@ export class ButtonComponent extends Component {
       className,
       target,
       loading,
-      tabIndex,
+      tabIndex = 0,
     } = this.props;
 
     const textOrMessage = message || text || children;
@@ -71,7 +71,7 @@ export class ButtonComponent extends Component {
         marginBottom: 0,
         marginLeft: 0,
       },
-      ...(tabIndex ? { tabIndex } : {}),
+      ...(tabIndex !== undefined && !disabled && !inert ? { tabIndex } : {}),
     };
 
     const marginStyles = {

--- a/src/Button/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/Button.test.js.snap
@@ -34,6 +34,7 @@ exports[`<Button /> handles various types ([none], primary, secondary, error, wa
           "marginTop": 0,
         }
       }
+      tabIndex={0}
     />
   </Ripples>
 </div>
@@ -73,6 +74,7 @@ exports[`<Button /> handles various types ([none], primary, secondary, error, wa
           "marginTop": 0,
         }
       }
+      tabIndex={0}
       type="error"
     />
   </Ripples>
@@ -113,6 +115,7 @@ exports[`<Button /> handles various types ([none], primary, secondary, error, wa
           "marginTop": 0,
         }
       }
+      tabIndex={0}
       type="info"
     />
   </Ripples>
@@ -153,6 +156,7 @@ exports[`<Button /> handles various types ([none], primary, secondary, error, wa
           "marginTop": 0,
         }
       }
+      tabIndex={0}
       type="primary"
     />
   </Ripples>
@@ -193,6 +197,7 @@ exports[`<Button /> handles various types ([none], primary, secondary, error, wa
           "marginTop": 0,
         }
       }
+      tabIndex={0}
       type="secondary"
     />
   </Ripples>
@@ -233,6 +238,7 @@ exports[`<Button /> handles various types ([none], primary, secondary, error, wa
           "marginTop": 0,
         }
       }
+      tabIndex={0}
       type="success"
     />
   </Ripples>
@@ -273,6 +279,7 @@ exports[`<Button /> handles various types ([none], primary, secondary, error, wa
           "marginTop": 0,
         }
       }
+      tabIndex={0}
       type="warning"
     />
   </Ripples>
@@ -313,6 +320,7 @@ exports[`<Button /> match snapshot 1`] = `
           "marginTop": 0,
         }
       }
+      tabIndex={0}
     />
   </Ripples>
 </div>

--- a/src/Input/Select/SelectWithFiltering.js
+++ b/src/Input/Select/SelectWithFiltering.js
@@ -666,6 +666,8 @@ class SelectWithFiltering extends Select {
     return (
       <SelectWithFilteringWrapper style={style}>
         <DropDown2
+          isFullWidth={isFullWidth}
+          fullWidthContent
           isOpen={isOpen}
           onClickOutside={this.handleDropDownChange}
           trigger={trigerer}
@@ -676,7 +678,7 @@ class SelectWithFiltering extends Select {
             style={{
               maxHeight: '320px',
               overflowY: 'auto',
-              minWidth: '180px',
+              width: '100%',
               background: 'white',
               ...(style.width ? { width: style.width } : {}),
               ...(isFullWidth ? { width: '100%' } : {}),

--- a/src/Input/Select/TriggerreWrapper.js
+++ b/src/Input/Select/TriggerreWrapper.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 
 const TriggerreWrapper = styled.div`
-  min-width: 180px;
+  /* min-width: 180px; */
   width: 100%;
   min-height: 34px;
   height: 34px;

--- a/src/Input/TextField.js
+++ b/src/Input/TextField.js
@@ -108,6 +108,7 @@ class TextField extends Component {
       success,
       error,
       defaultValue,
+      tabIndex = 0,
       ...attributes
     } = this.props;
 
@@ -118,6 +119,7 @@ class TextField extends Component {
 
     const inputAttributes = {
       ...attributes,
+      ...(tabIndex !== undefined ? { tabIndex } : {}),
       value: this.isControlled ? this.props.value : this.state.value,
     };
 
@@ -125,6 +127,7 @@ class TextField extends Component {
       <InputWrapperUI>
         <InputUI
           {...inputAttributes}
+
           type={type}
           style={style}
           placeholder={placeholder}

--- a/src/Input/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/Input/__tests__/__snapshots__/Select.test.js.snap
@@ -2,9 +2,11 @@
 
 exports[`<Select /> controlled/uncontrolled behaviour works as a controlled component, no onChange, no change 1`] = `
 <div
+  onKeyDown={null}
   style={Object {}}
 >
   <clickOutside(DropDownWithClickOutside)
+    fullWidthContent={true}
     isOpen={false}
     onChildrenWrapperRef={[Function]}
     onClickOutside={[Function]}
@@ -116,8 +118,8 @@ exports[`<Select /> controlled/uncontrolled behaviour works as a controlled comp
         Object {
           "background": "white",
           "maxHeight": "320px",
-          "minWidth": "180px",
           "overflowY": "auto",
+          "width": "100%",
         }
       }
     >
@@ -198,9 +200,11 @@ exports[`<Select /> controlled/uncontrolled behaviour works as a controlled comp
 
 exports[`<Select /> controlled/uncontrolled behaviour works correctly as an uncontrolled input 1`] = `
 <div
+  onKeyDown={null}
   style={Object {}}
 >
   <clickOutside(DropDownWithClickOutside)
+    fullWidthContent={true}
     isOpen={false}
     onChildrenWrapperRef={[Function]}
     onClickOutside={[Function]}
@@ -312,8 +316,8 @@ exports[`<Select /> controlled/uncontrolled behaviour works correctly as an unco
         Object {
           "background": "white",
           "maxHeight": "320px",
-          "minWidth": "180px",
           "overflowY": "auto",
+          "width": "100%",
         }
       }
     >
@@ -394,9 +398,11 @@ exports[`<Select /> controlled/uncontrolled behaviour works correctly as an unco
 
 exports[`<Select /> matches snapshot 1`] = `
 <div
+  onKeyDown={null}
   style={Object {}}
 >
   <clickOutside(DropDownWithClickOutside)
+    fullWidthContent={true}
     isOpen={false}
     onChildrenWrapperRef={[Function]}
     onClickOutside={[Function]}
@@ -480,8 +486,8 @@ exports[`<Select /> matches snapshot 1`] = `
         Object {
           "background": "white",
           "maxHeight": "320px",
-          "minWidth": "180px",
           "overflowY": "auto",
+          "width": "100%",
         }
       }
     />

--- a/src/Motion/Ripples.js
+++ b/src/Motion/Ripples.js
@@ -124,8 +124,8 @@ class Ripples extends Component {
     } = ev;
     const { top, left } = currentTarget.getBoundingClientRect();
 
-    const rippleLeft = pageX - left;
-    const rippleTop = clientY - top;
+    const rippleLeft = pageX ? pageX - left : '50%';
+    const rippleTop = clientY ? clientY - top : '50%';
 
     this.setState({
       rippleStyle: {

--- a/src/internal/DropDown2.js
+++ b/src/internal/DropDown2.js
@@ -9,6 +9,7 @@ const BoxWrapperUI = styled.div.attrs({})`
   position: absolute;
   max-height: 0;
   top: 100%;
+  ${({ fullWidthContent }) => (fullWidthContent ? 'width: 100%' : '')};
 
   /**
     * fix flex scroll bar issue on IE */
@@ -37,7 +38,7 @@ const BoxWrapperUI = styled.div.attrs({})`
     overflow-y: hidden;
   }
 
-
+  /* TODO shoadow and focus stylesshould be managed by component orchestrating a dropDown2 */
   &:focus, &:focus-within {
     ${({ /* isOpen,  */theme }) => (/* isOpen */ true
       ? `box-shadow: ${theme.outlineShadow}; outline: ${theme.outline}`
@@ -59,6 +60,7 @@ class DropDown2 extends Component {
 
   static defaultProps = {
     isOpen: undefined,
+    fullWidthContent: false,
     onTriggerWrapperRef: () => {},
     onChildrenWrapperRef: () => {},
     trigger: <div />,
@@ -147,6 +149,7 @@ class DropDown2 extends Component {
       children,
       isFullWidth,
       anchor,
+      fullWidthContent,
     } = this.props;
 
     const {
@@ -181,6 +184,7 @@ class DropDown2 extends Component {
           {TriggerWithHandler}
         </span>
         <BoxWrapperUI
+          fullWidthContent={fullWidthContent}
           data-box-wrapper-ui
           onScroll={(e) => {
             e.stopPropagation();


### PR DESCRIPTION
- better keyboard event managmt. on Select and Drawer when composed
  - solve double escape key event handling in case of component composition (like a Select in a Drawer)
- fix Select default minWidth (default was not sane and hardly overwritable)
- better ripple styles for keyboard event
- lint
- update snaphsots

no breaking changes (tested in widget and in IE - IE was already not supportting some of the feature of the Drawer)
