### PR TITLE
Update Td.js

### DIFF
--- a/src/DataGridv2/Td.js
+++ b/src/DataGridv2/Td.js
@@ -21,17 +21,23 @@ class Td extends React.Component {
   shouldComponentUpdate(nextProps) {
     const {
       isBeingResized,
+      isResizing,
       columnSize,
       columns = [],
       mComp,
       selected = [],
     } = this.props;
     const {
+      isResizing: willBeResizing,
       columnSize: nextColumnSize,
       mComp: nextmComp,
       columns: nextColumns = [],
       selected: nextSelected = [],
     } = nextProps;
+
+    if (isResizing && !willBeResizing) {
+      return true;
+    }
 
     if (selected.join(',') !== nextSelected.join(',')) {
       return true;

--- a/src/DataGridv2/Td.js
+++ b/src/DataGridv2/Td.js
@@ -18,6 +18,7 @@ const TdUI = styled.td.attrs(props => ({
 
 // eslint-disable-next-line react/prefer-stateless-function
 class Td extends React.Component {
+  /*
   shouldComponentUpdate(nextProps) {
     const {
       isBeingResized,
@@ -49,10 +50,10 @@ class Td extends React.Component {
       return true;
     }
 
-    /** Columns size can change on user input (dnd col resize)
-     * but also on mount,
-     * depending on props an available space
-     */
+    // Columns size can change on user input (dnd col resize)
+    // but also on mount,
+    // depending on props an available space
+    //
 
     if (columnSize !== nextColumnSize) {
       return true;
@@ -71,6 +72,7 @@ class Td extends React.Component {
 
     return false;
   }
+  */
 
   render() {
     return (

--- a/src/DataGridv2/Td.js
+++ b/src/DataGridv2/Td.js
@@ -1,7 +1,7 @@
 // @flow
 import styled from 'styled-components';
 import React from 'react';
-import isEqual from 'lodash/isEqual';
+// import isEqual from 'lodash/isEqual';
 
 const cellHeight = 48;
 

--- a/src/DataGridv2/Th.js
+++ b/src/DataGridv2/Th.js
@@ -100,7 +100,7 @@ class Th extends React.Component {
       }
     }
   }
-
+  /*
   shouldComponentUpdate(nextProps) {
     const {
       isBeingResized,
@@ -160,6 +160,7 @@ class Th extends React.Component {
 
     return false;
   }
+  */
   /*
 
   */


### PR DESCRIPTION
fix cell detail disapearing

We already are "disabling" CellDetail while resizing is ooccuring, so I guess we'd need too alerady go to next step of perf imprv. ?

https://github.com/uxilab/uxi/blob/master/src/DataGridv2/DataGrid.js#L664-L668

https://github.com/uxilab/uxi/blob/feature/denisflorkin-patch-1/src/DataGridv2/DataGrid.js#L664-L668
